### PR TITLE
Update release-drafter.yml

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: self-hosted
+    runs-on: [self-hosted, security, small]
     steps:
       # (Optional) GitHub Enterprise requires GHE_HOST variable set
       #- name: Set GHE_HOST


### PR DESCRIPTION
This is mainly motivated because we have an old configuration for self-hosted GitHub Action runners which doesn't scale down to zero, and a new configuration where the GitHub Action runners scale down to zero replicas and we can be more specific in the needs, indicating the size of the runner. So, I'll try to get rid of this old runner setup and at the same time, be more correct in the ownership/allocation of the GitHub Action Runners to have better visibility about the costs.

For instance, this is related to the old runners 
![image](https://github.com/empathyco/platform-k6-tests/assets/33934998/66af4249-fd8a-44bb-a0cb-22ce623d0f75)

The link for the GitHub Actions Runners can be found [here](https://grafana.infra.internal.shared.empathy.co/d/OCIDAg6Vz/k8-s-costs?orgId=1&from=now-2M&to=now&tab=query&var-Kubecost=kubecost_data&var-Teams=All&var-runners=All) It's WIP yet, but enough to review the costs.